### PR TITLE
Reconfigure the systemd service to refer the executable binaries from /usr/bin

### DIFF
--- a/resources/local-digital-twins.service
+++ b/resources/local-digital-twins.service
@@ -7,7 +7,7 @@ Requires=mosquitto.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/local-digital-twins -configFile /etc/local-digital-twins/config.json
+ExecStart=/usr/bin/local-digital-twins -configFile /etc/local-digital-twins/config.json
 Restart=always
 
 [Install]


### PR DESCRIPTION
[#4] Reconfigure the systemd service to refer the executable binaries from /usr/bin

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>