### PR TITLE
Provide integration tests for the key functionalities - digital twin command events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.17
 require (
 	github.com/Jeffail/gabs/v2 v2.6.1
 	github.com/ThreeDotsLabs/watermill v1.1.1
+	github.com/caarlos0/env/v6 v6.10.1
+	github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230323152903-9d6570b21206
 	github.com/eclipse-kanto/suite-connector v0.1.0-M2.0.20230222081206-577d4deaa329
+	github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3
 	github.com/imdario/mergo v0.3.12
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
@@ -16,7 +19,6 @@ require (
 require (
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.4.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/google/go-tpm v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
+github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -29,6 +31,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230323152903-9d6570b21206 h1:uJAIxnE6vRdlw8kWlTCeL3ekcESasLzKf8PMugExS6M=
+github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230323152903-9d6570b21206/go.mod h1:Dscvhc6K9RHiioYjZiQooqs13ffkPBhEvdlL4KdsJXs=
 github.com/eclipse-kanto/suite-connector v0.1.0-M2.0.20230222081206-577d4deaa329 h1:zq1hFh2Vbc89mOiBfs6WJZPJajOw9gvwtEFjFHLVS7s=
 github.com/eclipse-kanto/suite-connector v0.1.0-M2.0.20230222081206-577d4deaa329/go.mod h1:C0aJ1oZrLEIdk5FK25Fwa8BvlsnWTAyZmXQUcTMQGF4=
 github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3 h1:bfFGs26yNSfhSi6xmnmykB0jZn1Vu5e1/7JA5Wu5aGc=
@@ -52,6 +56,7 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/integration/ldt_desired_properties_test.go
+++ b/integration/ldt_desired_properties_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+)
+
+type ldtDesiredPropertiesSuite struct {
+	localDigitalTwinsSuite
+
+	messagesFilter string
+	expectedPath   string
+}
+
+func (suite *ldtDesiredPropertiesSuite) SetupSuite() {
+	suite.SetupLdtSuite()
+	suite.messagesFilter = fmt.Sprintf("like(resource:path,'/features/%s/desiredProperties')", featureID)
+	suite.expectedPath = fmt.Sprintf("/features/%s/desiredProperties", featureID)
+}
+
+func (suite *ldtDesiredPropertiesSuite) TearDownSuite() {
+	suite.TearDownLdtSuite()
+	suite.TearDown()
+}
+
+func TestDesiredPropertiesSuite(t *testing.T) {
+	suite.Run(t, new(ldtDesiredPropertiesSuite))
+}
+
+func (suite *ldtDesiredPropertiesSuite) TestEventModifyOrCreateDesiredProperties() {
+	properties := map[string]interface{}{desiredProperty: value}
+	tests := map[string]struct {
+		command        *things.Command
+		expectedTopic  string
+		beforeFunction func()
+	}{
+		"test_create_desired_properties": {
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureDesiredProperties(featureID).Modify(properties),
+			expectedTopic: suite.twinEventTopicCreated,
+			beforeFunction: func() {
+				suite.createTestFeature(emptyFeature, featureID)
+			},
+		},
+
+		"test_modify_desired_properties": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				FeatureDesiredProperties(featureID).Modify(properties),
+			expectedTopic: suite.twinEventTopicModified,
+			beforeFunction: func() {
+				suite.createTestFeature(featureWithDesiredProperties, featureID)
+			},
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.beforeFunction != nil {
+				testCase.beforeFunction()
+			}
+			suite.executeCommand("e", suite.messagesFilter, properties, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			b, _ := json.Marshal(properties)
+			body, err := suite.getAllDesiredPropertiesOfFeature(featureID)
+			require.NoError(suite.T(), err, "unable to get desired properties")
+			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "desired properties don't match")
+			suite.removeTestFeatures()
+		})
+	}
+}
+
+func (suite *ldtDesiredPropertiesSuite) TestEventDeleteDesiredProperties() {
+	command := things.NewCommand(suite.namespacedID).FeatureDesiredProperties(featureID).Delete()
+	expectedTopic := suite.twinEventTopicDeleted
+
+	suite.createTestFeature(featureWithDesiredProperties, featureID)
+	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+
+	body, err := suite.getAllDesiredPropertiesOfFeature(featureID)
+	require.Error(suite.T(), err, "desired properties of feature should have been deleted")
+	assert.Nil(suite.T(), body, "body should be nil")
+
+}

--- a/integration/ldt_desired_property_test.go
+++ b/integration/ldt_desired_property_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+)
+
+type ldtDesiredPropertySuite struct {
+	localDigitalTwinsSuite
+
+	messagesFilter string
+	expectedPath   string
+}
+
+func (suite *ldtDesiredPropertySuite) SetupSuite() {
+	suite.SetupLdtSuite()
+	suite.messagesFilter = fmt.Sprintf("like(resource:path,'/features/%s/desiredProperties/*')", featureID)
+	suite.expectedPath = fmt.Sprintf("/features/%s/desiredProperties/%s", featureID, desiredProperty)
+}
+
+func (suite *ldtDesiredPropertySuite) TearDownSuite() {
+	suite.TearDownLdtSuite()
+	suite.TearDown()
+}
+
+func TestDesiredPropertySuite(t *testing.T) {
+	suite.Run(t, new(ldtDesiredPropertySuite))
+}
+
+func (suite *ldtDesiredPropertySuite) TestEventModifyOrCreateProperty() {
+	tests := map[string]struct {
+		command        *things.Command
+		expectedTopic  string
+		beforeFunction func()
+	}{
+		"test_create_desired_property": {
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureDesiredProperty(featureID, desiredProperty).Modify(value),
+			expectedTopic: suite.twinEventTopicCreated,
+			beforeFunction: func() {
+				suite.createTestFeature(emptyFeature, featureID)
+			},
+		},
+
+		"test_modify_desired_property": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				FeatureDesiredProperty(featureID, desiredProperty).Modify(value),
+			expectedTopic: suite.twinEventTopicModified,
+			beforeFunction: func() {
+				suite.createTestFeature(featureWithDesiredProperties, featureID)
+			},
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.beforeFunction != nil {
+				testCase.beforeFunction()
+			}
+			suite.executeCommand("e", suite.messagesFilter, value, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			b, _ := json.Marshal(value)
+			body, err := suite.getDesiredPropertyOfFeature(featureID, desiredProperty)
+			require.NoError(suite.T(), err, "unable to get property")
+			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "desired property doesn't match")
+			suite.removeTestFeatures()
+		})
+	}
+}
+
+func (suite *ldtDesiredPropertySuite) TestEventDeleteDesiredProperty() {
+	command := things.NewCommand(suite.namespacedID).FeatureDesiredProperty(featureID, desiredProperty).Delete()
+	expectedTopic := suite.twinEventTopicDeleted
+
+	suite.createTestFeature(featureWithDesiredProperties, featureID)
+	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+
+	body, err := suite.getDesiredPropertyOfFeature(featureID, desiredProperty)
+	require.Error(suite.T(), err, fmt.Sprintf("Desired property with key: '%s' should have been deleted", desiredProperty))
+	assert.Nil(suite.T(), body, "body should be nil")
+
+}

--- a/integration/ldt_desired_property_test.go
+++ b/integration/ldt_desired_property_test.go
@@ -22,10 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/suite"
 )
 
 type ldtDesiredPropertySuite struct {
@@ -51,33 +50,23 @@ func TestDesiredPropertySuite(t *testing.T) {
 }
 
 func (suite *ldtDesiredPropertySuite) TestEventModifyOrCreateProperty() {
-	tests := map[string]struct {
-		command        *things.Command
-		expectedTopic  string
-		beforeFunction func()
-	}{
+	tests := map[string]ldtTestCaseData{
 		"test_create_desired_property": {
 			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureDesiredProperty(featureID, desiredProperty).Modify(value),
 			expectedTopic: suite.twinEventTopicCreated,
-			beforeFunction: func() {
-				suite.createTestFeature(emptyFeature, featureID)
-			},
+			feature:       emptyFeature,
 		},
 
 		"test_modify_desired_property": {
 			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
 				FeatureDesiredProperty(featureID, desiredProperty).Modify(value),
 			expectedTopic: suite.twinEventTopicModified,
-			beforeFunction: func() {
-				suite.createTestFeature(featureWithDesiredProperties, featureID)
-			},
+			feature:       featureWithDesiredProperties,
 		},
 	}
 	for testName, testCase := range tests {
 		suite.Run(testName, func() {
-			if testCase.beforeFunction != nil {
-				testCase.beforeFunction()
-			}
+			suite.createTestFeature(testCase.feature, featureID)
 			suite.executeCommand("e", suite.messagesFilter, value, testCase.command, suite.expectedPath, testCase.expectedTopic)
 			b, _ := json.Marshal(value)
 			body, err := suite.getDesiredPropertyOfFeature(featureID, desiredProperty)

--- a/integration/ldt_feature_test.go
+++ b/integration/ldt_feature_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/require"
+)
+
+type ldtFeatureSuite struct {
+	localDigitalTwinsSuite
+
+	messagesFilter string
+	expectedPath   string
+}
+
+func (suite *ldtFeatureSuite) SetupSuite() {
+	suite.SetupLdtSuite()
+	suite.messagesFilter = "like(resource:path,'/features/*')"
+	suite.expectedPath = fmt.Sprintf("/features/%s", featureID)
+
+}
+
+func (suite *ldtFeatureSuite) TearDownSuite() {
+	suite.TearDownLdtSuite()
+	suite.TearDown()
+}
+
+func TestFeatureSuite(t *testing.T) {
+	suite.Run(t, new(ldtFeatureSuite))
+}
+
+func (suite *ldtFeatureSuite) TestEventModifyOrCreateFeature() {
+	tests := map[string]struct {
+		command        *things.Command
+		expectedTopic  string
+		beforeFunction func()
+	}{
+		"test_create_feature": {
+			command: things.NewCommand(suite.namespacedID).Twin().
+				Feature(featureID).Modify(emptyFeature),
+			expectedTopic: suite.twinEventTopicCreated,
+		},
+
+		"test_modify_feature": {
+			command: things.NewCommand(suite.namespacedID).Twin().
+				Feature(featureID).Modify(emptyFeature),
+			expectedTopic: suite.twinEventTopicModified,
+			beforeFunction: func() {
+				suite.createTestFeature(emptyFeature, featureID)
+			},
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.beforeFunction != nil {
+				testCase.beforeFunction()
+			}
+			suite.executeCommand("e", suite.messagesFilter, emptyFeature, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			b, _ := json.Marshal(emptyFeature)
+			body, err := suite.getFeature(featureID)
+			require.NoError(suite.T(), err, "unable to get feature")
+			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "feature doesn't match")
+			suite.removeTestFeatures()
+		})
+	}
+}
+
+func (suite *ldtFeatureSuite) TestEventDeleteFeature() {
+	command := things.NewCommand(suite.namespacedID).Twin().Feature(featureID).Delete()
+	expectedTopic := suite.twinEventTopicDeleted
+
+	suite.createTestFeature(emptyFeature, featureID)
+	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+
+	body, err := suite.getFeature(featureID)
+	require.Error(suite.T(), err, "feature should have been deleted")
+	assert.Nil(suite.T(), body, "body should be nil")
+}

--- a/integration/ldt_feature_test.go
+++ b/integration/ldt_feature_test.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 type ldtFeatureSuite struct {
@@ -51,11 +50,7 @@ func TestFeatureSuite(t *testing.T) {
 }
 
 func (suite *ldtFeatureSuite) TestEventModifyOrCreateFeature() {
-	tests := map[string]struct {
-		command        *things.Command
-		expectedTopic  string
-		beforeFunction func()
-	}{
+	tests := map[string]ldtTestCaseData{
 		"test_create_feature": {
 			command: things.NewCommand(suite.namespacedID).Twin().
 				Feature(featureID).Modify(emptyFeature),
@@ -66,15 +61,13 @@ func (suite *ldtFeatureSuite) TestEventModifyOrCreateFeature() {
 			command: things.NewCommand(suite.namespacedID).Twin().
 				Feature(featureID).Modify(emptyFeature),
 			expectedTopic: suite.twinEventTopicModified,
-			beforeFunction: func() {
-				suite.createTestFeature(emptyFeature, featureID)
-			},
+			feature:       emptyFeature,
 		},
 	}
 	for testName, testCase := range tests {
 		suite.Run(testName, func() {
-			if testCase.beforeFunction != nil {
-				testCase.beforeFunction()
+			if testCase.feature != nil {
+				suite.createTestFeature(testCase.feature, featureID)
 			}
 			suite.executeCommand("e", suite.messagesFilter, emptyFeature, testCase.command, suite.expectedPath, testCase.expectedTopic)
 			b, _ := json.Marshal(emptyFeature)

--- a/integration/ldt_features_test.go
+++ b/integration/ldt_features_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/require"
+)
+
+type ldtFeaturesSuite struct {
+	localDigitalTwinsSuite
+
+	messagesFilter string
+	expectedPath   string
+}
+
+func (suite *ldtFeaturesSuite) SetupSuite() {
+	suite.SetupLdtSuite()
+	suite.messagesFilter = "like(resource:path,'/features')"
+	suite.expectedPath = "/features"
+}
+
+func (suite *ldtFeaturesSuite) TearDownSuite() {
+	suite.TearDownLdtSuite()
+	suite.TearDown()
+}
+
+func TestFeaturesSuite(t *testing.T) {
+	suite.Run(t, new(ldtFeaturesSuite))
+}
+
+func (suite *ldtFeaturesSuite) TestEventModifyOrCreateFeatures() {
+	features := map[string]*model.Feature{featureID: emptyFeature}
+
+	tests := map[string]struct {
+		command        *things.Command
+		expectedTopic  string
+		beforeFunction func()
+	}{
+		"test_create_features": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				Features().Modify(features),
+			expectedTopic: suite.twinEventTopicCreated,
+		},
+
+		"test_modify_features": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				Features().Modify(features),
+			expectedTopic: suite.twinEventTopicModified,
+			beforeFunction: func() {
+				suite.createTestFeature(emptyFeature, featureID)
+			},
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.beforeFunction != nil {
+				testCase.beforeFunction()
+			}
+			suite.executeCommand("e", suite.messagesFilter, features, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			b, _ := json.Marshal(features)
+			body, err := suite.getAllFeatures()
+			require.NoError(suite.T(), err, "unable to get features")
+			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "features don't match")
+			suite.removeTestFeatures()
+		})
+	}
+}
+func (suite *ldtFeaturesSuite) TestEventDeleteFeatures() {
+	command := things.NewCommand(suite.namespacedID).Twin().Features().Delete()
+	expectedTopic := suite.twinEventTopicDeleted
+
+	suite.createTestFeature(emptyFeature, featureID)
+	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+
+	body, err := suite.getAllFeatures()
+	require.Error(suite.T(), err, "features should have been deleted")
+	assert.Nil(suite.T(), body, "body should be nil")
+}

--- a/integration/ldt_features_test.go
+++ b/integration/ldt_features_test.go
@@ -20,11 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 type ldtFeaturesSuite struct {
@@ -52,11 +51,7 @@ func TestFeaturesSuite(t *testing.T) {
 func (suite *ldtFeaturesSuite) TestEventModifyOrCreateFeatures() {
 	features := map[string]*model.Feature{featureID: emptyFeature}
 
-	tests := map[string]struct {
-		command        *things.Command
-		expectedTopic  string
-		beforeFunction func()
-	}{
+	tests := map[string]ldtTestCaseData{
 		"test_create_features": {
 			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
 				Features().Modify(features),
@@ -67,15 +62,13 @@ func (suite *ldtFeaturesSuite) TestEventModifyOrCreateFeatures() {
 			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
 				Features().Modify(features),
 			expectedTopic: suite.twinEventTopicModified,
-			beforeFunction: func() {
-				suite.createTestFeature(emptyFeature, featureID)
-			},
+			feature:       emptyFeature,
 		},
 	}
 	for testName, testCase := range tests {
 		suite.Run(testName, func() {
-			if testCase.beforeFunction != nil {
-				testCase.beforeFunction()
+			if testCase.feature != nil {
+				suite.createTestFeature(testCase.feature, featureID)
 			}
 			suite.executeCommand("e", suite.messagesFilter, features, testCase.command, suite.expectedPath, testCase.expectedTopic)
 			b, _ := json.Marshal(features)

--- a/integration/ldt_properties_test.go
+++ b/integration/ldt_properties_test.go
@@ -22,10 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/suite"
 )
 
 type ldtPropertiesSuite struct {
@@ -52,33 +51,23 @@ func TestPropertiesSuite(t *testing.T) {
 
 func (suite *ldtPropertiesSuite) TestEventModifyOrCreateProperties() {
 	properties := map[string]interface{}{property: value}
-	tests := map[string]struct {
-		command        *things.Command
-		expectedTopic  string
-		beforeFunction func()
-	}{
+	tests := map[string]ldtTestCaseData{
 		"test_create_properties": {
 			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureProperties(featureID).Modify(properties),
 			expectedTopic: suite.twinEventTopicCreated,
-			beforeFunction: func() {
-				suite.createTestFeature(emptyFeature, featureID)
-			},
+			feature:       emptyFeature,
 		},
 
 		"test_modify_properties": {
 			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
 				FeatureProperties(featureID).Modify(properties),
 			expectedTopic: suite.twinEventTopicModified,
-			beforeFunction: func() {
-				suite.createTestFeature(featureWithProperties, featureID)
-			},
+			feature:       featureWithProperties,
 		},
 	}
 	for testName, testCase := range tests {
 		suite.Run(testName, func() {
-			if testCase.beforeFunction != nil {
-				testCase.beforeFunction()
-			}
+			suite.createTestFeature(testCase.feature, featureID)
 			suite.executeCommand("e", suite.messagesFilter, properties, testCase.command, suite.expectedPath, testCase.expectedTopic)
 			b, _ := json.Marshal(properties)
 			body, err := suite.getAllPropertiesOfFeature(featureID)

--- a/integration/ldt_properties_test.go
+++ b/integration/ldt_properties_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+)
+
+type ldtPropertiesSuite struct {
+	localDigitalTwinsSuite
+
+	messagesFilter string
+	expectedPath   string
+}
+
+func (suite *ldtPropertiesSuite) SetupSuite() {
+	suite.SetupLdtSuite()
+	suite.messagesFilter = fmt.Sprintf("like(resource:path,'/features/%s/properties')", featureID)
+	suite.expectedPath = fmt.Sprintf("/features/%s/properties", featureID)
+}
+
+func (suite *ldtPropertiesSuite) TearDownSuite() {
+	suite.TearDownLdtSuite()
+	suite.TearDown()
+}
+
+func TestPropertiesSuite(t *testing.T) {
+	suite.Run(t, new(ldtPropertiesSuite))
+}
+
+func (suite *ldtPropertiesSuite) TestEventModifyOrCreateProperties() {
+	properties := map[string]interface{}{property: value}
+	tests := map[string]struct {
+		command        *things.Command
+		expectedTopic  string
+		beforeFunction func()
+	}{
+		"test_create_properties": {
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureProperties(featureID).Modify(properties),
+			expectedTopic: suite.twinEventTopicCreated,
+			beforeFunction: func() {
+				suite.createTestFeature(emptyFeature, featureID)
+			},
+		},
+
+		"test_modify_properties": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				FeatureProperties(featureID).Modify(properties),
+			expectedTopic: suite.twinEventTopicModified,
+			beforeFunction: func() {
+				suite.createTestFeature(featureWithProperties, featureID)
+			},
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.beforeFunction != nil {
+				testCase.beforeFunction()
+			}
+			suite.executeCommand("e", suite.messagesFilter, properties, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			b, _ := json.Marshal(properties)
+			body, err := suite.getAllPropertiesOfFeature(featureID)
+			require.NoError(suite.T(), err, "unable to get properties")
+			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "properties don't match")
+			suite.removeTestFeatures()
+		})
+	}
+}
+func (suite *ldtPropertiesSuite) TestEventDeleteProperties() {
+	command := things.NewCommand(suite.namespacedID).Twin().FeatureProperties(featureID).Delete()
+	expectedTopic := suite.twinEventTopicDeleted
+	suite.createTestFeature(featureWithProperties, featureID)
+	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	body, err := suite.getAllPropertiesOfFeature(featureID)
+	require.Error(suite.T(), err, "properties should have been deleted")
+	assert.Nil(suite.T(), body, "body should be nil")
+}

--- a/integration/ldt_property_test.go
+++ b/integration/ldt_property_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+)
+
+type ldtPropertySuite struct {
+	localDigitalTwinsSuite
+
+	messagesFilter string
+	expectedPath   string
+}
+
+func (suite *ldtPropertySuite) SetupSuite() {
+	suite.SetupLdtSuite()
+	suite.messagesFilter = fmt.Sprintf("like(resource:path,'/features/%s/properties/*')", featureID)
+	suite.expectedPath = fmt.Sprintf("/features/%s/properties/%s", featureID, property)
+}
+
+func (suite *ldtPropertySuite) TearDownSuite() {
+	suite.TearDownLdtSuite()
+	suite.TearDown()
+}
+
+func TestPropertySuite(t *testing.T) {
+	suite.Run(t, new(ldtPropertySuite))
+}
+
+func (suite *ldtPropertySuite) TestEventModifyOrCreateProperty() {
+	tests := map[string]struct {
+		command        *things.Command
+		expectedTopic  string
+		beforeFunction func()
+	}{
+		"test_create_property": {
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureProperty(featureID, property).Modify(value),
+			expectedTopic: suite.twinEventTopicCreated,
+			beforeFunction: func() {
+				suite.createTestFeature(emptyFeature, featureID)
+			},
+		},
+
+		"test_modify_property": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				FeatureProperty(featureID, property).Modify(value),
+			expectedTopic: suite.twinEventTopicModified,
+			beforeFunction: func() {
+				suite.createTestFeature(featureWithProperties, featureID)
+			},
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.beforeFunction != nil {
+				testCase.beforeFunction()
+			}
+			suite.executeCommand("e", suite.messagesFilter, value, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			b, _ := json.Marshal(value)
+			body, err := suite.getPropertyOfFeature(featureID, property)
+			require.NoError(suite.T(), err, "unable to get property")
+			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "property doesn't match")
+			suite.removeTestFeatures()
+		})
+	}
+}
+func (suite *ldtPropertySuite) TestEventDeleteProperty() {
+	command := things.NewCommand(suite.namespacedID).Twin().FeatureProperty(featureID, property).Delete()
+	expectedTopic := suite.twinEventTopicDeleted
+	suite.createTestFeature(featureWithProperties, featureID)
+	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	body, err := suite.getPropertyOfFeature(featureID, property)
+	require.Error(suite.T(), err, fmt.Sprintf("Property with key: '%s' should have been deleted", property))
+	assert.Nil(suite.T(), body, "body should be nil")
+}

--- a/integration/ldt_property_test.go
+++ b/integration/ldt_property_test.go
@@ -22,10 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/suite"
 )
 
 type ldtPropertySuite struct {
@@ -51,33 +50,23 @@ func TestPropertySuite(t *testing.T) {
 }
 
 func (suite *ldtPropertySuite) TestEventModifyOrCreateProperty() {
-	tests := map[string]struct {
-		command        *things.Command
-		expectedTopic  string
-		beforeFunction func()
-	}{
+	tests := map[string]ldtTestCaseData{
 		"test_create_property": {
 			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureProperty(featureID, property).Modify(value),
 			expectedTopic: suite.twinEventTopicCreated,
-			beforeFunction: func() {
-				suite.createTestFeature(emptyFeature, featureID)
-			},
+			feature:       emptyFeature,
 		},
 
 		"test_modify_property": {
 			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
 				FeatureProperty(featureID, property).Modify(value),
 			expectedTopic: suite.twinEventTopicModified,
-			beforeFunction: func() {
-				suite.createTestFeature(featureWithProperties, featureID)
-			},
+			feature:       featureWithProperties,
 		},
 	}
 	for testName, testCase := range tests {
 		suite.Run(testName, func() {
-			if testCase.beforeFunction != nil {
-				testCase.beforeFunction()
-			}
+			suite.createTestFeature(testCase.feature, featureID)
 			suite.executeCommand("e", suite.messagesFilter, value, testCase.command, suite.expectedPath, testCase.expectedTopic)
 			b, _ := json.Marshal(value)
 			body, err := suite.getPropertyOfFeature(featureID, property)

--- a/integration/ldt_suite.go
+++ b/integration/ldt_suite.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/caarlos0/env/v6"
+	"github.com/eclipse-kanto/kanto/integration/util"
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol"
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"reflect"
+)
+
+type ldtTestConfiguration struct {
+	StatusTimeoutMs             int    `env:"SCT_STATUS_TIMEOUT_MS" envDefault:"10000"`
+	StatusReadySinceTimeDeltaMs int    `env:"SCT_STATUS_READY_SINCE_TIME_DELTA_MS" envDefault:"0"`
+	StatusRetryIntervalMs       int    `env:"SCT_STATUS_RETRY_INTERVAL_MS" envDefault:"2000"`
+	PolicyId                    string `env:"POLICY_ID"`
+}
+
+type localDigitalTwinsSuite struct {
+	suite.Suite
+	util.SuiteInitializer
+
+	thingURL               string
+	namespacedID           *model.NamespacedID
+	ldtTestConfiguration   *ldtTestConfiguration
+	twinEventTopicModified string
+	twinEventTopicDeleted  string
+	twinEventTopicCreated  string
+}
+
+func (suite *localDigitalTwinsSuite) SetupLdtSuite() {
+	suite.Setup(suite.T())
+
+	ldtTestCfg := &ldtTestConfiguration{}
+	opts := env.Options{RequiredIfNoDef: true}
+	require.NoError(suite.T(), env.Parse(ldtTestCfg, opts),
+		"failed to process suite connector test environment variables")
+	suite.ldtTestConfiguration = ldtTestCfg
+	suite.thingURL = util.GetThingURL(suite.Cfg.DigitalTwinAPIAddress, suite.ThingCfg.DeviceID)
+	suite.twinEventTopicModified = util.GetTwinEventTopic(suite.ThingCfg.DeviceID, protocol.ActionModified)
+	suite.twinEventTopicCreated = util.GetTwinEventTopic(suite.ThingCfg.DeviceID, protocol.ActionCreated)
+	suite.twinEventTopicDeleted = util.GetTwinEventTopic(suite.ThingCfg.DeviceID, protocol.ActionDeleted)
+	suite.namespacedID = model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)
+	suite.createTestThing((&model.Thing{}).WithID(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).WithPolicyIDFrom(suite.ldtTestConfiguration.PolicyId))
+
+}
+
+func (suite *localDigitalTwinsSuite) TearDownLdtSuite() {
+	suite.removeTestThing()
+	suite.TearDown()
+
+}
+
+func (suite *localDigitalTwinsSuite) getFeatureDesiredPropertyValue(featureURL string, property string) ([]byte, error) {
+	url := fmt.Sprintf(featureDesiredPropertyURLTemplate, featureURL, property)
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, url, nil)
+}
+
+func (suite *localDigitalTwinsSuite) getAllPropertiesOfFeature(featureID string) ([]byte, error) {
+	featureURL := util.GetFeatureURL(suite.thingURL, featureID)
+	url := fmt.Sprintf(featurePropertyURLTemplate, featureURL, "")
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, url, nil)
+}
+
+func (suite *localDigitalTwinsSuite) getAllDesiredPropertiesOfFeature(featureID string) ([]byte, error) {
+	featureURL := util.GetFeatureURL(suite.thingURL, featureID)
+	url := fmt.Sprintf(featureDesiredPropertyURLTemplate, featureURL, "")
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, url, nil)
+}
+
+func (suite *localDigitalTwinsSuite) getDesiredPropertyOfFeature(featureID string, property string) ([]byte, error) {
+	featureURL := util.GetFeatureURL(suite.thingURL, featureID)
+	url := fmt.Sprintf(featureDesiredPropertyURLTemplate, featureURL, property)
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, url, nil)
+}
+
+func (suite *localDigitalTwinsSuite) getPropertyOfFeature(featureID string, property string) ([]byte, error) {
+	featureURL := util.GetFeatureURL(suite.thingURL, featureID)
+	url := fmt.Sprintf(featurePropertyURLTemplate, featureURL, property)
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, url, nil)
+}
+
+func (suite *localDigitalTwinsSuite) getFeature(featureID string) ([]byte, error) {
+	featureURL := util.GetFeatureURL(suite.thingURL, featureID)
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, featureURL, nil)
+}
+
+func (suite *localDigitalTwinsSuite) getAllFeatures() ([]byte, error) {
+	URL := fmt.Sprintf("%s/features", suite.thingURL)
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, URL, nil)
+}
+
+func (suite *localDigitalTwinsSuite) getThing() ([]byte, error) {
+	return util.SendDigitalTwinRequest(suite.Cfg, http.MethodGet, suite.thingURL, nil)
+}
+
+func convertValueToJSON(value interface{}) map[string]interface{} {
+	byteValue, _ := json.Marshal(value)
+	jsonValue := make(map[string]interface{})
+	json.Unmarshal(byteValue, &jsonValue)
+
+	return jsonValue
+}
+
+func (suite *localDigitalTwinsSuite) createTestFeature(feature *model.Feature, featureID string) {
+	cmd := things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Feature(featureID).
+		Modify(feature)
+	msg := cmd.Envelope(protocol.WithResponseRequired(false))
+	err := suite.DittoClient.Send(msg)
+	require.NoError(suite.T(), err, "creation of test feature failed")
+}
+
+func (suite *localDigitalTwinsSuite) createTestThing(thing *model.Thing) {
+	cmd := things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Create(thing)
+	msg := cmd.Envelope(protocol.WithResponseRequired(false))
+	err := suite.DittoClient.Send(msg)
+	require.NoError(suite.T(), err, "creation of test thing failed")
+}
+
+func (suite *localDigitalTwinsSuite) removeTestFeatures() {
+	cmd := things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Features().Delete()
+	msg := cmd.Envelope(protocol.WithResponseRequired(false))
+	err := suite.DittoClient.Send(msg)
+	require.NoError(suite.T(), err, "removal of test features failed")
+}
+
+func (suite *localDigitalTwinsSuite) removeTestThing() {
+	cmd := things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Delete()
+	msg := cmd.Envelope(protocol.WithResponseRequired(false))
+	err := suite.DittoClient.Send(msg)
+	require.NoError(suite.T(), err, "removal of test thing failed")
+}
+
+func (suite *localDigitalTwinsSuite) executeCommand(topic string, filter string, newValue interface{}, command *things.Command, expectedPath string, expectedTopic string) {
+	ws, err := util.NewDigitalTwinWSConnection(suite.Cfg)
+	require.NoError(suite.T(), err, "cannot create a websocket connection to the backend")
+	defer ws.Close()
+
+	err = util.SubscribeForWSMessages(suite.Cfg, ws, util.StartSendEvents, filter)
+	require.NoError(suite.T(), err, "subscription for events should succeed")
+	defer util.UnsubscribeFromWSMessages(suite.Cfg, ws, util.StopSendEvents)
+
+	msg := command.Envelope(protocol.WithResponseRequired(true))
+
+	err = util.SendMQTTMessage(suite.Cfg, suite.MQTTClient, topic, msg)
+	require.NoError(suite.T(), err, "unable to send event to the backend")
+
+	result := util.ProcessWSMessages(suite.Cfg, ws, func(msg *protocol.Envelope) (bool, error) {
+
+		if newValue != nil {
+			if reflect.TypeOf(newValue).Kind() != reflect.String {
+				newValue = convertValueToJSON(newValue)
+			}
+		}
+
+		if expectedTopic == msg.Topic.String() && expectedPath == msg.Path &&
+			reflect.DeepEqual(msg.Value, newValue) {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("unexpected value: %s", msg.Value)
+	})
+	require.NoError(suite.T(), result, "event should be received")
+}

--- a/integration/ldt_test_constants.go
+++ b/integration/ldt_test_constants.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import "github.com/eclipse/ditto-clients-golang/model"
+
+const (
+	featurePropertyURLTemplate        = "%s/properties/%s"
+	featureDesiredPropertyURLTemplate = "%s/desiredProperties/%s"
+	desiredProperty                   = "testDesiredProperty"
+	featureID                         = "testFeature"
+	property                          = "testProperty"
+	value                             = "testValue"
+)
+
+var (
+	emptyFeature                 = &model.Feature{}
+	featureWithDesiredProperties = (&model.Feature{}).WithDesiredProperty(desiredProperty, value)
+	featureWithProperties        = (&model.Feature{}).WithProperty(property, value)
+)

--- a/integration/ldt_thing_test.go
+++ b/integration/ldt_thing_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol"
+	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/require"
+)
+
+type ldtThingSuite struct {
+	localDigitalTwinsSuite
+
+	messagesFilter string
+	expectedPath   string
+}
+
+func (suite *ldtThingSuite) SetupSuite() {
+	suite.SetupLdtSuite()
+	suite.messagesFilter = "like(resource:path,'/')"
+	suite.expectedPath = "/"
+}
+
+func (suite *ldtThingSuite) TearDownSuite() {
+	suite.TearDownLdtSuite()
+	suite.TearDown()
+}
+
+func TestThingSuite(t *testing.T) {
+	suite.Run(t, new(ldtThingSuite))
+}
+
+func (suite *ldtThingSuite) TestEventModifyOrCreateThing() {
+	thing := &model.Thing{}
+	thing.WithID(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID))
+	thing.WithPolicyIDFrom(suite.ldtTestConfiguration.PolicyId)
+
+	tests := map[string]struct {
+		command        *things.Command
+		expectedTopic  string
+		beforeFunction func()
+	}{
+		"test_modify_thing": {
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Modify(thing),
+			expectedTopic: suite.twinEventTopicModified,
+		},
+		"test_create_thing": {
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Create(thing),
+			expectedTopic: suite.twinEventTopicCreated,
+			beforeFunction: func() {
+				cmd := things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Delete()
+				msg := cmd.Envelope(protocol.WithResponseRequired(false))
+				err := suite.DittoClient.Send(msg)
+				require.NoError(suite.T(), err, "removed test thing")
+			},
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.beforeFunction != nil {
+				testCase.beforeFunction()
+			}
+			suite.executeCommand("e", suite.messagesFilter, thing, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			b, _ := json.Marshal(thing)
+			body, err := suite.getThing()
+			require.NoError(suite.T(), err, "unable to get thing")
+			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "thing updated")
+		})
+	}
+}
+
+func (suite *ldtThingSuite) TestEventDeleteThing() {
+	thing := &model.Thing{}
+	thing.WithID(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID))
+	thing.WithPolicyIDFrom(suite.ldtTestConfiguration.PolicyId)
+	command := things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Delete()
+	expectedTopic := suite.twinEventTopicDeleted
+	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	body, err := suite.getThing()
+	require.Error(suite.T(), err, "thing should have been deleted")
+	assert.Nil(suite.T(), body, "body should be nil")
+
+	suite.createTestThing(thing)
+}


### PR DESCRIPTION
[#26] Provide integration tests for the key functionalities - digital twin command events

Created integration tests for the command-event communication pattern. Tests cover all entity levels and the create, modify and delete commands.