### PR TITLE
Provide integration tests for the key functionalities - digital twin command response

### DIFF
--- a/integration/ldt_feature_test.go
+++ b/integration/ldt_feature_test.go
@@ -17,11 +17,11 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -52,14 +52,12 @@ func TestFeatureSuite(t *testing.T) {
 func (suite *ldtFeatureSuite) TestEventModifyOrCreateFeature() {
 	tests := map[string]ldtTestCaseData{
 		"test_create_feature": {
-			command: things.NewCommand(suite.namespacedID).Twin().
-				Feature(featureID).Modify(emptyFeature),
+			command:       things.NewCommand(suite.namespacedID).Twin().Feature(featureID).Modify(emptyFeature),
 			expectedTopic: suite.twinEventTopicCreated,
 		},
 
 		"test_modify_feature": {
-			command: things.NewCommand(suite.namespacedID).Twin().
-				Feature(featureID).Modify(emptyFeature),
+			command:       things.NewCommand(suite.namespacedID).Twin().Feature(featureID).Modify(emptyFeature),
 			expectedTopic: suite.twinEventTopicModified,
 			feature:       emptyFeature,
 		},
@@ -74,20 +72,15 @@ func (suite *ldtFeatureSuite) TestEventModifyOrCreateFeature() {
 			actualBody, err := suite.getFeature(featureID)
 			require.NoError(suite.T(), err, "unable to get feature")
 
-			expectedMap := suite.convertToMap(expectedBody)
-			actualMap := suite.convertToMap(actualBody)
-			assert.True(suite.T(), reflect.DeepEqual(expectedMap, actualMap))
+			assert.True(suite.T(), reflect.DeepEqual(suite.convertToMap(expectedBody), suite.convertToMap(actualBody)))
 			suite.removeTestFeatures()
 		})
 	}
 }
 
 func (suite *ldtFeatureSuite) TestEventDeleteFeature() {
-	command := things.NewCommand(suite.namespacedID).Twin().Feature(featureID).Delete()
-	expectedTopic := suite.twinEventTopicDeleted
-
 	suite.createTestFeature(emptyFeature, featureID)
-	suite.executeCommandEvent("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	suite.executeCommandEvent("e", suite.messagesFilter, nil, things.NewCommand(suite.namespacedID).Twin().Feature(featureID).Delete(), suite.expectedPath, suite.twinEventTopicDeleted)
 
 	body, err := suite.getFeature(featureID)
 	require.Error(suite.T(), err, "feature should have been deleted")
@@ -97,13 +90,12 @@ func (suite *ldtFeatureSuite) TestEventDeleteFeature() {
 func (suite *ldtFeatureSuite) TestCommandResponseModifyOrCreateFeature() {
 	tests := map[string]ldtTestCaseData{
 		"test_create_feature": {
-			command: things.NewCommand(suite.namespacedID).Twin().
-				Feature(featureID).Modify(emptyFeature), expectedStatusCode: 201,
+			command:            things.NewCommand(suite.namespacedID).Twin().Feature(featureID).Modify(emptyFeature),
+			expectedStatusCode: 201,
 		},
 
 		"test_modify_feature": {
-			command: things.NewCommand(suite.namespacedID).Twin().
-				Feature(featureID).Modify(emptyFeature),
+			command:            things.NewCommand(suite.namespacedID).Twin().Feature(featureID).Modify(emptyFeature),
 			expectedStatusCode: 204,
 			feature:            emptyFeature,
 		},
@@ -122,21 +114,18 @@ func (suite *ldtFeatureSuite) TestCommandResponseModifyOrCreateFeature() {
 }
 
 func (suite *ldtFeatureSuite) TestCommandResponseDeleteFeature() {
-	command := things.NewCommand(suite.namespacedID).Feature(featureID).Delete()
 	suite.createTestFeature(emptyFeature, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).Feature(featureID).Delete())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 204, response.Status, "unexpected status code")
 }
 
 func (suite *ldtFeatureSuite) TestCommandResponseRetrieveFeature() {
-	command := things.NewCommand(suite.namespacedID).Feature(featureID).Retrieve()
 	suite.createTestFeature(emptyFeature, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).Feature(featureID).Retrieve())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 200, response.Status, "unexpected status code")
-	actualBody, _ := suite.getFeature(featureID)
+	actualBody, err := suite.getFeature(featureID)
 	require.NoError(suite.T(), err, "unable to get feature")
-	actualMap := suite.convertToMap(actualBody)
-	assert.True(suite.T(), reflect.DeepEqual(response.Value, actualMap))
+	assert.True(suite.T(), reflect.DeepEqual(response.Value, suite.convertToMap(actualBody)))
 }

--- a/integration/ldt_features_test.go
+++ b/integration/ldt_features_test.go
@@ -16,12 +16,12 @@ package integration
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -51,14 +51,12 @@ func TestFeaturesSuite(t *testing.T) {
 func (suite *ldtFeaturesSuite) TestEventModifyOrCreateFeatures() {
 	tests := map[string]ldtTestCaseData{
 		"test_create_features": {
-			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
-				Features().Modify(features),
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Features().Modify(features),
 			expectedTopic: suite.twinEventTopicCreated,
 		},
 
 		"test_modify_features": {
-			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
-				Features().Modify(features),
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Features().Modify(features),
 			expectedTopic: suite.twinEventTopicModified,
 			feature:       emptyFeature,
 		},
@@ -73,19 +71,14 @@ func (suite *ldtFeaturesSuite) TestEventModifyOrCreateFeatures() {
 			actualBody, err := suite.getAllFeatures()
 			require.NoError(suite.T(), err, "unable to get features")
 
-			expectedMap := suite.convertToMap(expectedBody)
-			actualMap := suite.convertToMap(actualBody)
-			assert.True(suite.T(), reflect.DeepEqual(expectedMap, actualMap))
+			assert.True(suite.T(), reflect.DeepEqual(suite.convertToMap(expectedBody), suite.convertToMap(actualBody)))
 			suite.removeTestFeatures()
 		})
 	}
 }
 func (suite *ldtFeaturesSuite) TestEventDeleteFeatures() {
-	command := things.NewCommand(suite.namespacedID).Twin().Features().Delete()
-	expectedTopic := suite.twinEventTopicDeleted
-
 	suite.createTestFeature(emptyFeature, featureID)
-	suite.executeCommandEvent("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	suite.executeCommandEvent("e", suite.messagesFilter, nil, things.NewCommand(suite.namespacedID).Twin().Features().Delete(), suite.expectedPath, suite.twinEventTopicDeleted)
 
 	body, err := suite.getAllFeatures()
 	require.Error(suite.T(), err, "features should have been deleted")
@@ -95,14 +88,12 @@ func (suite *ldtFeaturesSuite) TestEventDeleteFeatures() {
 func (suite *ldtFeaturesSuite) TestCommandResponseModifyOrCreateFeatures() {
 	tests := map[string]ldtTestCaseData{
 		"test_create_features": {
-			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
-				Features().Modify(features),
+			command:            things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Features().Modify(features),
 			expectedStatusCode: 201,
 		},
 
 		"test_modify_features": {
-			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
-				Features().Modify(features),
+			command:            things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Features().Modify(features),
 			expectedStatusCode: 204,
 			feature:            emptyFeature,
 		},
@@ -121,21 +112,19 @@ func (suite *ldtFeaturesSuite) TestCommandResponseModifyOrCreateFeatures() {
 }
 
 func (suite *ldtFeaturesSuite) TestCommandResponseDeleteFeatures() {
-	command := things.NewCommand(suite.namespacedID).Features().Delete()
 	suite.createTestFeature(emptyFeature, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).Features().Delete())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 204, response.Status, "unexpected status code")
 }
 
 func (suite *ldtFeaturesSuite) TestCommandResponseRetrieveFeatures() {
-	command := things.NewCommand(suite.namespacedID).Features().Retrieve()
 	suite.createTestFeature(emptyFeature, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).Features().Retrieve())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 200, response.Status, "unexpected status code")
+
 	actualBody, err := suite.getAllFeatures()
 	require.NoError(suite.T(), err, "unable to get features")
-	actualMap := suite.convertToMap(actualBody)
-	assert.True(suite.T(), reflect.DeepEqual(response.Value, actualMap))
+	assert.True(suite.T(), reflect.DeepEqual(response.Value, suite.convertToMap(actualBody)))
 }

--- a/integration/ldt_features_test.go
+++ b/integration/ldt_features_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
-	"strings"
+	"reflect"
 	"testing"
 
 	"github.com/eclipse/ditto-clients-golang/model"
@@ -49,8 +49,6 @@ func TestFeaturesSuite(t *testing.T) {
 }
 
 func (suite *ldtFeaturesSuite) TestEventModifyOrCreateFeatures() {
-	features := map[string]*model.Feature{featureID: emptyFeature}
-
 	tests := map[string]ldtTestCaseData{
 		"test_create_features": {
 			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
@@ -70,11 +68,14 @@ func (suite *ldtFeaturesSuite) TestEventModifyOrCreateFeatures() {
 			if testCase.feature != nil {
 				suite.createTestFeature(testCase.feature, featureID)
 			}
-			suite.executeCommand("e", suite.messagesFilter, features, testCase.command, suite.expectedPath, testCase.expectedTopic)
-			b, _ := json.Marshal(features)
-			body, err := suite.getAllFeatures()
+			suite.executeCommandEvent("e", suite.messagesFilter, features, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			expectedBody, _ := json.Marshal(features)
+			actualBody, err := suite.getAllFeatures()
 			require.NoError(suite.T(), err, "unable to get features")
-			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "features don't match")
+
+			expectedMap := suite.convertToMap(expectedBody)
+			actualMap := suite.convertToMap(actualBody)
+			assert.True(suite.T(), reflect.DeepEqual(expectedMap, actualMap))
 			suite.removeTestFeatures()
 		})
 	}
@@ -84,9 +85,57 @@ func (suite *ldtFeaturesSuite) TestEventDeleteFeatures() {
 	expectedTopic := suite.twinEventTopicDeleted
 
 	suite.createTestFeature(emptyFeature, featureID)
-	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	suite.executeCommandEvent("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
 
 	body, err := suite.getAllFeatures()
 	require.Error(suite.T(), err, "features should have been deleted")
 	assert.Nil(suite.T(), body, "body should be nil")
+}
+
+func (suite *ldtFeaturesSuite) TestCommandResponseModifyOrCreateFeatures() {
+	tests := map[string]ldtTestCaseData{
+		"test_create_features": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				Features().Modify(features),
+			expectedStatusCode: 201,
+		},
+
+		"test_modify_features": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				Features().Modify(features),
+			expectedStatusCode: 204,
+			feature:            emptyFeature,
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.feature != nil {
+				suite.createTestFeature(testCase.feature, featureID)
+			}
+			response, err := suite.executeCommandResponse(testCase.command)
+			require.NoError(suite.T(), err, "could not get response")
+			assert.Equal(suite.T(), testCase.expectedStatusCode, response.Status, "unexpected status code")
+			suite.removeTestFeatures()
+		})
+	}
+}
+
+func (suite *ldtFeaturesSuite) TestCommandResponseDeleteFeatures() {
+	command := things.NewCommand(suite.namespacedID).Features().Delete()
+	suite.createTestFeature(emptyFeature, featureID)
+	response, err := suite.executeCommandResponse(command)
+	require.NoError(suite.T(), err, "could not get response")
+	assert.Equal(suite.T(), 204, response.Status, "unexpected status code")
+}
+
+func (suite *ldtFeaturesSuite) TestCommandResponseRetrieveFeatures() {
+	command := things.NewCommand(suite.namespacedID).Features().Retrieve()
+	suite.createTestFeature(emptyFeature, featureID)
+	response, err := suite.executeCommandResponse(command)
+	require.NoError(suite.T(), err, "could not get response")
+	assert.Equal(suite.T(), 200, response.Status, "unexpected status code")
+	actualBody, err := suite.getAllFeatures()
+	require.NoError(suite.T(), err, "unable to get features")
+	actualMap := suite.convertToMap(actualBody)
+	assert.True(suite.T(), reflect.DeepEqual(response.Value, actualMap))
 }

--- a/integration/ldt_properties_test.go
+++ b/integration/ldt_properties_test.go
@@ -17,10 +17,11 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
@@ -72,18 +73,14 @@ func (suite *ldtPropertiesSuite) TestEventModifyOrCreateProperties() {
 			actualBody, err := suite.getAllPropertiesOfFeature(featureID)
 			require.NoError(suite.T(), err, "unable to get properties")
 
-			expectedMap := suite.convertToMap(expectedBody)
-			actualMap := suite.convertToMap(actualBody)
-			assert.True(suite.T(), reflect.DeepEqual(expectedMap, actualMap))
+			assert.True(suite.T(), reflect.DeepEqual(suite.convertToMap(expectedBody), suite.convertToMap(actualBody)))
 			suite.removeTestFeatures()
 		})
 	}
 }
 func (suite *ldtPropertiesSuite) TestEventDeleteProperties() {
-	command := things.NewCommand(suite.namespacedID).Twin().FeatureProperties(featureID).Delete()
-	expectedTopic := suite.twinEventTopicDeleted
 	suite.createTestFeature(featureWithProperties, featureID)
-	suite.executeCommandEvent("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	suite.executeCommandEvent("e", suite.messagesFilter, nil, things.NewCommand(suite.namespacedID).Twin().FeatureProperties(featureID).Delete(), suite.expectedPath, suite.twinEventTopicDeleted)
 	body, err := suite.getAllPropertiesOfFeature(featureID)
 	require.Error(suite.T(), err, "properties should have been deleted")
 	assert.Nil(suite.T(), body, "body should be nil")
@@ -116,21 +113,18 @@ func (suite *ldtPropertiesSuite) TestCommandResponseModifyOrCreateProperties() {
 }
 
 func (suite *ldtPropertiesSuite) TestCommandResponseDeleteProperties() {
-	command := things.NewCommand(suite.namespacedID).FeatureProperties(featureID).Delete()
 	suite.createTestFeature(featureWithProperties, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).FeatureProperties(featureID).Delete())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 204, response.Status, "unexpected status code")
 }
 
 func (suite *ldtPropertiesSuite) TestCommandResponseRetrieveProperties() {
-	command := things.NewCommand(suite.namespacedID).FeatureProperties(featureID).Retrieve()
 	suite.createTestFeature(featureWithProperties, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).FeatureProperties(featureID).Retrieve())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 200, response.Status, "unexpected status code")
-	actualBody, _ := suite.getAllPropertiesOfFeature(featureID)
+	actualBody, err := suite.getAllPropertiesOfFeature(featureID)
 	require.NoError(suite.T(), err, "unable to get properties")
-	actualMap := suite.convertToMap(actualBody)
-	assert.True(suite.T(), reflect.DeepEqual(response.Value, actualMap))
+	assert.True(suite.T(), reflect.DeepEqual(response.Value, suite.convertToMap(actualBody)))
 }

--- a/integration/ldt_property_test.go
+++ b/integration/ldt_property_test.go
@@ -17,13 +17,13 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol/things"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -77,10 +77,8 @@ func (suite *ldtPropertySuite) TestEventModifyOrCreateProperty() {
 	}
 }
 func (suite *ldtPropertySuite) TestEventDeleteProperty() {
-	command := things.NewCommand(suite.namespacedID).Twin().FeatureProperty(featureID, property).Delete()
-	expectedTopic := suite.twinEventTopicDeleted
 	suite.createTestFeature(featureWithProperties, featureID)
-	suite.executeCommandEvent("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	suite.executeCommandEvent("e", suite.messagesFilter, nil, things.NewCommand(suite.namespacedID).Twin().FeatureProperty(featureID, property).Delete(), suite.expectedPath, suite.twinEventTopicDeleted)
 	body, err := suite.getPropertyOfFeature(featureID, property)
 	require.Error(suite.T(), err, fmt.Sprintf("Property with key: '%s' should have been deleted", property))
 	assert.Nil(suite.T(), body, "body should be nil")
@@ -113,20 +111,19 @@ func (suite *ldtPropertySuite) TestCommandResponseModifyOrCreateProperty() {
 }
 
 func (suite *ldtPropertySuite) TestCommandResponseDeleteProperty() {
-	command := things.NewCommand(suite.namespacedID).FeatureProperty(featureID, property).Delete()
 	suite.createTestFeature(featureWithProperties, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).FeatureProperty(featureID, property).Delete())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 204, response.Status, "unexpected status code")
 }
 
 func (suite *ldtPropertySuite) TestCommandResponseRetrieveProperty() {
-	command := things.NewCommand(suite.namespacedID).FeatureProperty(featureID, property).Retrieve()
 	suite.createTestFeature(featureWithProperties, featureID)
-	response, err := suite.executeCommandResponse(command)
+	response, err := suite.executeCommandResponse(things.NewCommand(suite.namespacedID).FeatureProperty(featureID, property).Retrieve())
 	require.NoError(suite.T(), err, "could not get response")
 	assert.Equal(suite.T(), 200, response.Status, "unexpected status code")
 	body, _ := suite.getPropertyOfFeature(featureID, property)
-	b, _ := json.Marshal(response.Value)
+	b, err := json.Marshal(response.Value)
+	require.NoError(suite.T(), err, "unable to marshal the response value")
 	assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)))
 }

--- a/integration/ldt_property_test.go
+++ b/integration/ldt_property_test.go
@@ -67,7 +67,7 @@ func (suite *ldtPropertySuite) TestEventModifyOrCreateProperty() {
 	for testName, testCase := range tests {
 		suite.Run(testName, func() {
 			suite.createTestFeature(testCase.feature, featureID)
-			suite.executeCommand("e", suite.messagesFilter, value, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			suite.executeCommandEvent("e", suite.messagesFilter, value, testCase.command, suite.expectedPath, testCase.expectedTopic)
 			b, _ := json.Marshal(value)
 			body, err := suite.getPropertyOfFeature(featureID, property)
 			require.NoError(suite.T(), err, "unable to get property")
@@ -80,8 +80,53 @@ func (suite *ldtPropertySuite) TestEventDeleteProperty() {
 	command := things.NewCommand(suite.namespacedID).Twin().FeatureProperty(featureID, property).Delete()
 	expectedTopic := suite.twinEventTopicDeleted
 	suite.createTestFeature(featureWithProperties, featureID)
-	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	suite.executeCommandEvent("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
 	body, err := suite.getPropertyOfFeature(featureID, property)
 	require.Error(suite.T(), err, fmt.Sprintf("Property with key: '%s' should have been deleted", property))
 	assert.Nil(suite.T(), body, "body should be nil")
+}
+
+func (suite *ldtPropertySuite) TestCommandResponseModifyOrCreateProperty() {
+	tests := map[string]ldtTestCaseData{
+		"test_create_property": {
+			command:            things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().FeatureProperty(featureID, property).Modify(value),
+			expectedStatusCode: 201,
+			feature:            emptyFeature,
+		},
+
+		"test_modify_property": {
+			command: things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().
+				FeatureProperty(featureID, property).Modify(value),
+			expectedStatusCode: 204,
+			feature:            featureWithProperties,
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			suite.createTestFeature(testCase.feature, featureID)
+			response, err := suite.executeCommandResponse(testCase.command)
+			require.NoError(suite.T(), err, "could not get response")
+			assert.Equal(suite.T(), testCase.expectedStatusCode, response.Status, "unexpected status code")
+			suite.removeTestFeatures()
+		})
+	}
+}
+
+func (suite *ldtPropertySuite) TestCommandResponseDeleteProperty() {
+	command := things.NewCommand(suite.namespacedID).FeatureProperty(featureID, property).Delete()
+	suite.createTestFeature(featureWithProperties, featureID)
+	response, err := suite.executeCommandResponse(command)
+	require.NoError(suite.T(), err, "could not get response")
+	assert.Equal(suite.T(), 204, response.Status, "unexpected status code")
+}
+
+func (suite *ldtPropertySuite) TestCommandResponseRetrieveProperty() {
+	command := things.NewCommand(suite.namespacedID).FeatureProperty(featureID, property).Retrieve()
+	suite.createTestFeature(featureWithProperties, featureID)
+	response, err := suite.executeCommandResponse(command)
+	require.NoError(suite.T(), err, "could not get response")
+	assert.Equal(suite.T(), 200, response.Status, "unexpected status code")
+	body, _ := suite.getPropertyOfFeature(featureID, property)
+	b, _ := json.Marshal(response.Value)
+	assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)))
 }

--- a/integration/ldt_test_constants.go
+++ b/integration/ldt_test_constants.go
@@ -29,4 +29,6 @@ var (
 	emptyFeature                 = &model.Feature{}
 	featureWithDesiredProperties = (&model.Feature{}).WithDesiredProperty(desiredProperty, value)
 	featureWithProperties        = (&model.Feature{}).WithProperty(property, value)
+	properties                   = map[string]interface{}{desiredProperty: value}
+	features                     = map[string]*model.Feature{featureID: emptyFeature}
 )

--- a/integration/ldt_thing_test.go
+++ b/integration/ldt_thing_test.go
@@ -17,7 +17,7 @@ package integration
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
-	"strings"
+	"reflect"
 	"testing"
 
 	"github.com/eclipse/ditto-clients-golang/model"
@@ -30,6 +30,7 @@ import (
 type ldtThingSuite struct {
 	localDigitalTwinsSuite
 
+	thing          *model.Thing
 	messagesFilter string
 	expectedPath   string
 }
@@ -38,6 +39,8 @@ func (suite *ldtThingSuite) SetupSuite() {
 	suite.SetupLdtSuite()
 	suite.messagesFilter = "like(resource:path,'/')"
 	suite.expectedPath = "/"
+
+	suite.thing = (&model.Thing{}).WithID(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).WithPolicyIDFrom(suite.ldtTestConfiguration.PolicyId)
 }
 
 func (suite *ldtThingSuite) TearDownSuite() {
@@ -50,17 +53,14 @@ func TestThingSuite(t *testing.T) {
 }
 
 func (suite *ldtThingSuite) TestEventModifyOrCreateThing() {
-	thing := &model.Thing{}
-	thing.WithID(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID))
-	thing.WithPolicyIDFrom(suite.ldtTestConfiguration.PolicyId)
 
 	tests := map[string]ldtTestCaseData{
 		"test_modify_thing": {
-			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Modify(thing),
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Modify(suite.thing),
 			expectedTopic: suite.twinEventTopicModified,
 		},
 		"test_create_thing": {
-			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Create(thing),
+			command:       things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Create(suite.thing),
 			expectedTopic: suite.twinEventTopicCreated,
 		},
 	}
@@ -69,25 +69,68 @@ func (suite *ldtThingSuite) TestEventModifyOrCreateThing() {
 			if testCase.command.Topic.Action == protocol.ActionCreate {
 				suite.removeTestThing()
 			}
-			suite.executeCommand("e", suite.messagesFilter, thing, testCase.command, suite.expectedPath, testCase.expectedTopic)
-			b, _ := json.Marshal(thing)
-			body, err := suite.getThing()
+			suite.executeCommandEvent("e", suite.messagesFilter, suite.thing, testCase.command, suite.expectedPath, testCase.expectedTopic)
+			expectedBody, _ := json.Marshal(suite.thing)
+			actualBody, err := suite.getThing()
 			require.NoError(suite.T(), err, "unable to get thing")
-			assert.Equal(suite.T(), string(b), strings.TrimSpace(string(body)), "thing updated")
+
+			expectedMap := suite.convertToMap(expectedBody)
+			actualMap := suite.convertToMap(actualBody)
+			assert.True(suite.T(), reflect.DeepEqual(expectedMap, actualMap))
 		})
 	}
 }
 
 func (suite *ldtThingSuite) TestEventDeleteThing() {
-	thing := &model.Thing{}
-	thing.WithID(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID))
-	thing.WithPolicyIDFrom(suite.ldtTestConfiguration.PolicyId)
 	command := things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Delete()
 	expectedTopic := suite.twinEventTopicDeleted
-	suite.executeCommand("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
+	suite.executeCommandEvent("e", suite.messagesFilter, nil, command, suite.expectedPath, expectedTopic)
 	body, err := suite.getThing()
 	require.Error(suite.T(), err, "thing should have been deleted")
 	assert.Nil(suite.T(), body, "body should be nil")
 
-	suite.createTestThing(thing)
+	suite.createTestThing(suite.thing)
+}
+
+func (suite *ldtThingSuite) TestCommandResponseModifyOrCreateThing() {
+	tests := map[string]ldtTestCaseData{
+		"test_create_thing": {
+			command:            things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Create(suite.thing),
+			expectedStatusCode: 201,
+		},
+
+		"test_modify_thing": {
+			command:            things.NewCommand(model.NewNamespacedIDFrom(suite.ThingCfg.DeviceID)).Twin().Modify(suite.thing),
+			expectedStatusCode: 204,
+		},
+	}
+	for testName, testCase := range tests {
+		suite.Run(testName, func() {
+			if testCase.command.Topic.Action == protocol.ActionCreate {
+				suite.removeTestThing()
+			}
+			response, err := suite.executeCommandResponse(testCase.command)
+			require.NoError(suite.T(), err, "could not get response")
+			assert.Equal(suite.T(), testCase.expectedStatusCode, response.Status, "unexpected status code")
+		})
+	}
+}
+
+func (suite *ldtThingSuite) TestCommandResponseDeleteThing() {
+	command := things.NewCommand(suite.namespacedID).Delete()
+	response, err := suite.executeCommandResponse(command)
+	require.NoError(suite.T(), err, "could not get response")
+	assert.Equal(suite.T(), 204, response.Status, "unexpected status code")
+	suite.createTestThing(suite.thing)
+}
+
+func (suite *ldtThingSuite) TestCommandResponseRetrieveThing() {
+	command := things.NewCommand(suite.namespacedID).Retrieve()
+	response, err := suite.executeCommandResponse(command)
+	require.NoError(suite.T(), err, "could not get response")
+	assert.Equal(suite.T(), 200, response.Status, "unexpected status code")
+	actualBody, err := suite.getThing()
+	require.NoError(suite.T(), err, "unable to get thing")
+	actualMap := suite.convertToMap(actualBody)
+	assert.True(suite.T(), reflect.DeepEqual(response.Value, actualMap))
 }


### PR DESCRIPTION
[#27] Provide integration tests for the key functionalities - digital twin command response
Created integration tests for the command-response communication pattern. Tests cover all entity levels and the create, modify, delete and retrieve commands.